### PR TITLE
Correct typo in namespace name: Loyality to Loyalty

### DIFF
--- a/LoyaltyCardsWebApi.API.Tests/Services/AuthServiceTest.cs
+++ b/LoyaltyCardsWebApi.API.Tests/Services/AuthServiceTest.cs
@@ -1,6 +1,6 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
-using LoyalityCardsWebApi.API.Repositories;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Repositories;
 using LoyaltyCardsWebApi.API.Services;
 using Microsoft.AspNetCore.Http;
 using Moq;

--- a/LoyaltyCardsWebApi.API/Controllers/AuthController.cs
+++ b/LoyaltyCardsWebApi.API/Controllers/AuthController.cs
@@ -1,7 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
-using LoyalityCardsWebApi.API.Repositories;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Repositories;
 using LoyaltyCardsWebApi.API.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;

--- a/LoyaltyCardsWebApi.API/Controllers/UsersController.cs
+++ b/LoyaltyCardsWebApi.API/Controllers/UsersController.cs
@@ -1,11 +1,11 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
-using LoyalityCardsWebApi.API.Repositories;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Repositories;
 using LoyaltyCardsWebApi.API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace LoyalityCardsWebApi.API.Controllers;
+namespace LoyaltyCardsWebApi.API.Controllers;
 
 [Route("api/[controller]")]
 public class UsersController : ControllerBase

--- a/LoyaltyCardsWebApi.API/Data/AppDbContext.cs
+++ b/LoyaltyCardsWebApi.API/Data/AppDbContext.cs
@@ -1,5 +1,5 @@
 using Microsoft.EntityFrameworkCore;
-using LoyalityCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Models;
 
 public class AppDbContext : DbContext
 {

--- a/LoyaltyCardsWebApi.API/Data/Configuration/JwtSettings.cs
+++ b/LoyaltyCardsWebApi.API/Data/Configuration/JwtSettings.cs
@@ -1,3 +1,3 @@
-namespace LoyalityCardsWebApi.API.Data.Configuration;
+namespace LoyaltyCardsWebApi.API.Data.Configuration;
 
 public record JwtSettings(string SecretKey, string ExpirationMinutes, string Issuer, string Audience);

--- a/LoyaltyCardsWebApi.API/Data/DTOs/CreateUserDto.cs
+++ b/LoyaltyCardsWebApi.API/Data/DTOs/CreateUserDto.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace LoyalityCardsWebApi.API.Data.DTOs;
+namespace LoyaltyCardsWebApi.API.Data.DTOs;
 public class CreateUserDto
     {
         public required string UserName { get; set; }

--- a/LoyaltyCardsWebApi.API/Data/DTOs/LoginDto.cs
+++ b/LoyaltyCardsWebApi.API/Data/DTOs/LoginDto.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace LoyalityCardsWebApi.API.Data.DTOs;
+namespace LoyaltyCardsWebApi.API.Data.DTOs;
 
 public class LoginDto
 {

--- a/LoyaltyCardsWebApi.API/Data/DTOs/UpdatedUserDto.cs
+++ b/LoyaltyCardsWebApi.API/Data/DTOs/UpdatedUserDto.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace LoyalityCardsWebApi.API.Data.DTOs;
+namespace LoyaltyCardsWebApi.API.Data.DTOs;
 public class UpdatedUserDto
 {
     [EmailAddress(ErrorMessage = "Invalid email address format")]

--- a/LoyaltyCardsWebApi.API/Data/DTOs/UserDto.cs
+++ b/LoyaltyCardsWebApi.API/Data/DTOs/UserDto.cs
@@ -1,4 +1,4 @@
-namespace LoyalityCardsWebApi.API.Data.DTOs;
+namespace LoyaltyCardsWebApi.API.Data.DTOs;
 
 public class UserDto
 {

--- a/LoyaltyCardsWebApi.API/Data/Models/Card.cs
+++ b/LoyaltyCardsWebApi.API/Data/Models/Card.cs
@@ -1,4 +1,4 @@
-namespace LoyalityCardsWebApi.API.Models;
+namespace LoyaltyCardsWebApi.API.Models;
 
 public class Card 
 {

--- a/LoyaltyCardsWebApi.API/Data/Models/RevokedToken.cs
+++ b/LoyaltyCardsWebApi.API/Data/Models/RevokedToken.cs
@@ -1,4 +1,4 @@
-namespace LoyalityCardsWebApi.API.Models;
+namespace LoyaltyCardsWebApi.API.Models;
 
 public class RevokedToken
 {

--- a/LoyaltyCardsWebApi.API/Data/Models/User.cs
+++ b/LoyaltyCardsWebApi.API/Data/Models/User.cs
@@ -1,6 +1,6 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Data.DTOs;
 
-namespace LoyalityCardsWebApi.API.Models;
+namespace LoyaltyCardsWebApi.API.Models;
 public class User
 {
     public int Id { get; set;}

--- a/LoyaltyCardsWebApi.API/Extensions/UserExtension.cs
+++ b/LoyaltyCardsWebApi.API/Extensions/UserExtension.cs
@@ -1,5 +1,5 @@
-using LoyalityCardsWebApi.API.Models;
-using LoyalityCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Data.DTOs;
 
 namespace LoyaltyCardsWebApi.API.Extensions;
 

--- a/LoyaltyCardsWebApi.API/Middleware/TokenRevocationMiddleware.cs
+++ b/LoyaltyCardsWebApi.API/Middleware/TokenRevocationMiddleware.cs
@@ -1,6 +1,6 @@
 using LoyaltyCardsWebApi.API.Services;
 
-namespace LoyalityCardsWebApi.API.Middleware;
+namespace LoyaltyCardsWebApi.API.Middleware;
 
 public class TokenRevocationMiddleware
 {

--- a/LoyaltyCardsWebApi.API/Migrations/20250303155736_InitialCreate.Designer.cs
+++ b/LoyaltyCardsWebApi.API/Migrations/20250303155736_InitialCreate.Designer.cs
@@ -24,7 +24,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.Card", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.Card", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -57,7 +57,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("Cards");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.User", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.User", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -94,9 +94,9 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("Users");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.Card", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.Card", b =>
                 {
-                    b.HasOne("LoyalityCardsWebApi.API.Models.User", "User")
+                    b.HasOne("LoyaltyCardsWebApi.API.Models.User", "User")
                         .WithMany("Cards")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -105,7 +105,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.User", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.User", b =>
                 {
                     b.Navigation("Cards");
                 });

--- a/LoyaltyCardsWebApi.API/Migrations/20250303155933_AddRevokedToken.Designer.cs
+++ b/LoyaltyCardsWebApi.API/Migrations/20250303155933_AddRevokedToken.Designer.cs
@@ -24,7 +24,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.Card", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.Card", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -57,7 +57,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("Cards");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.RevokedToken", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.RevokedToken", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -82,7 +82,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("RevokedToken");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.User", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.User", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -119,9 +119,9 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("Users");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.Card", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.Card", b =>
                 {
-                    b.HasOne("LoyalityCardsWebApi.API.Models.User", "User")
+                    b.HasOne("LoyaltyCardsWebApi.API.Models.User", "User")
                         .WithMany("Cards")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -130,9 +130,9 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.RevokedToken", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.RevokedToken", b =>
                 {
-                    b.HasOne("LoyalityCardsWebApi.API.Models.User", "User")
+                    b.HasOne("LoyaltyCardsWebApi.API.Models.User", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -141,7 +141,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.User", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.User", b =>
                 {
                     b.Navigation("Cards");
                 });

--- a/LoyaltyCardsWebApi.API/Migrations/AppDbContextModelSnapshot.cs
+++ b/LoyaltyCardsWebApi.API/Migrations/AppDbContextModelSnapshot.cs
@@ -21,7 +21,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.Card", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.Card", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -54,7 +54,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("Cards");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.RevokedToken", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.RevokedToken", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -79,7 +79,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("RevokedToken");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.User", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.User", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -116,9 +116,9 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.ToTable("Users");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.Card", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.Card", b =>
                 {
-                    b.HasOne("LoyalityCardsWebApi.API.Models.User", "User")
+                    b.HasOne("LoyaltyCardsWebApi.API.Models.User", "User")
                         .WithMany("Cards")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -127,9 +127,9 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.RevokedToken", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.RevokedToken", b =>
                 {
-                    b.HasOne("LoyalityCardsWebApi.API.Models.User", "User")
+                    b.HasOne("LoyaltyCardsWebApi.API.Models.User", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -138,7 +138,7 @@ namespace LoyaltyCardsWebApi.API.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("LoyalityCardsWebApi.API.Models.User", b =>
+            modelBuilder.Entity("LoyaltyCardsWebApi.API.Models.User", b =>
                 {
                     b.Navigation("Cards");
                 });

--- a/LoyaltyCardsWebApi.API/Program.cs
+++ b/LoyaltyCardsWebApi.API/Program.cs
@@ -1,12 +1,12 @@
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using DotNetEnv;
-using LoyalityCardsWebApi.API.Repositories;
+using LoyaltyCardsWebApi.API.Repositories;
 using LoyaltyCardsWebApi.API.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
-using LoyalityCardsWebApi.API.Middleware;
+using LoyaltyCardsWebApi.API.Middleware;
 
 DotNetEnv.Env.Load();
 var builder = WebApplication.CreateBuilder(args);

--- a/LoyaltyCardsWebApi.API/Repositories/AuthRepository.cs
+++ b/LoyaltyCardsWebApi.API/Repositories/AuthRepository.cs
@@ -1,5 +1,5 @@
-using LoyalityCardsWebApi.API.Models;
-using LoyalityCardsWebApi.API.Repositories;
+using LoyaltyCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 public class AuthRepository : IAuthRepository

--- a/LoyaltyCardsWebApi.API/Repositories/CardRepository.cs
+++ b/LoyaltyCardsWebApi.API/Repositories/CardRepository.cs
@@ -1,6 +1,6 @@
-using LoyalityCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Models;
 
-namespace LoyalityCardsWebApi.API.Repositories;
+namespace LoyaltyCardsWebApi.API.Repositories;
 
 public class CardRepository : ICardRepository
 {

--- a/LoyaltyCardsWebApi.API/Repositories/IAuthRepository.cs
+++ b/LoyaltyCardsWebApi.API/Repositories/IAuthRepository.cs
@@ -1,6 +1,6 @@
-using LoyalityCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Models;
 
-namespace LoyalityCardsWebApi.API.Repositories;
+namespace LoyaltyCardsWebApi.API.Repositories;
 public interface IAuthRepository
 {
     Task<RevokedToken> AddRevokedTokenAsync(string token, DateTime expiryDate, int userId);

--- a/LoyaltyCardsWebApi.API/Repositories/ICardRepository.cs
+++ b/LoyaltyCardsWebApi.API/Repositories/ICardRepository.cs
@@ -1,6 +1,6 @@
-using LoyalityCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Models;
 
-namespace LoyalityCardsWebApi.API.Repositories;
+namespace LoyaltyCardsWebApi.API.Repositories;
 public interface ICardRepository
 {
     Task<IEnumerable<Card>> GetCards();

--- a/LoyaltyCardsWebApi.API/Repositories/IUserRepository.cs
+++ b/LoyaltyCardsWebApi.API/Repositories/IUserRepository.cs
@@ -1,7 +1,7 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
 
-namespace LoyalityCardsWebApi.API.Repositories;
+namespace LoyaltyCardsWebApi.API.Repositories;
 public interface IUserRepository
 {
     Task<User?> GetUserByIdAsync(int id);

--- a/LoyaltyCardsWebApi.API/Repositories/UserRepository.cs
+++ b/LoyaltyCardsWebApi.API/Repositories/UserRepository.cs
@@ -1,8 +1,8 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace LoyalityCardsWebApi.API.Repositories;
+namespace LoyaltyCardsWebApi.API.Repositories;
 public class UserRepository : IUserRepository
 {
     private readonly AppDbContext _appDbContext;

--- a/LoyaltyCardsWebApi.API/Services/AuthService.cs
+++ b/LoyaltyCardsWebApi.API/Services/AuthService.cs
@@ -1,8 +1,8 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
-using LoyalityCardsWebApi.API.Repositories;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Repositories;
 
 namespace LoyaltyCardsWebApi.API.Services;
 

--- a/LoyaltyCardsWebApi.API/Services/IAuthService.cs
+++ b/LoyaltyCardsWebApi.API/Services/IAuthService.cs
@@ -1,4 +1,4 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Data.DTOs;
 
 namespace LoyaltyCardsWebApi.API.Services;
 public interface IAuthService

--- a/LoyaltyCardsWebApi.API/Services/IUserService.cs
+++ b/LoyaltyCardsWebApi.API/Services/IUserService.cs
@@ -1,5 +1,5 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
 
 namespace LoyaltyCardsWebApi.API.Services;
 public interface IUserService

--- a/LoyaltyCardsWebApi.API/Services/JwtService.cs
+++ b/LoyaltyCardsWebApi.API/Services/JwtService.cs
@@ -1,7 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
-using LoyalityCardsWebApi.API.Data.Configuration;
+using LoyaltyCardsWebApi.API.Data.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
 namespace LoyaltyCardsWebApi.API.Services;

--- a/LoyaltyCardsWebApi.API/Services/UserService.cs
+++ b/LoyaltyCardsWebApi.API/Services/UserService.cs
@@ -1,6 +1,6 @@
-using LoyalityCardsWebApi.API.Data.DTOs;
-using LoyalityCardsWebApi.API.Models;
-using LoyalityCardsWebApi.API.Repositories;
+using LoyaltyCardsWebApi.API.Data.DTOs;
+using LoyaltyCardsWebApi.API.Models;
+using LoyaltyCardsWebApi.API.Repositories;
 using System.Security.Claims;
 using LoyaltyCardsWebApi.API.Extensions;
 


### PR DESCRIPTION
Thank you for your contribution to the LoyaltyCardsWebApi repo. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Description
This Pull Request addresses a typographical error in the namespace name across the solution. The following changes have been made as part of this task::

### Bug Fixes:
- Corrected a typo in the namespace name: changed all occurrences of Loyality to Loyalty throughout the codebase.

### Affected Files:
- Updated namespace declarations in relevant .cs files.
- Adjusted related using statements, test files, and project references to match the corrected namespace.

### Why are these changes necessary?
Consistent and correct naming is important for code readability, maintainability, and to avoid confusion. Fixing the typo in the namespace improves the overall quality of the codebase and prevents potential issues with code referencing and future development.

### How to Test?
- Build the project to ensure there are no errors or unresolved references.
- Run all unit tests to verify that nothing is broken as a result of the namespace change:
 
dotnet test

- Optionally, verify project references and using statements in your IDE to confirm there are no lingering references to the old namespace.

### Are there any known issues or improvements to be made?
- No known issues related to this namespace change.
- If any references to the old namespace are found in downstream projects, they should be updated accordingly.
