### PR TITLE
Extract JWT authentication to extension and update tests to use DI-based configuration

### DIFF
--- a/LoyaltyCardsWebApi.API/Extensions/AuthenticationExtensions.cs
+++ b/LoyaltyCardsWebApi.API/Extensions/AuthenticationExtensions.cs
@@ -10,6 +10,19 @@ public static class AuthenticationExtensions
 {
     public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, string jwtIssuer, string jwtAudience, string secretKey)
     {
+        if (string.IsNullOrWhiteSpace(jwtIssuer))
+        {
+            throw new ArgumentException("JWT issuer must not be null, empty, or whitespace.", nameof(jwtIssuer));
+        }
+        if (string.IsNullOrWhiteSpace(jwtAudience))
+        {
+            throw new ArgumentException("JWT audience must not be null, empty, or whitespace.", nameof(jwtAudience));
+        }
+        if (string.IsNullOrWhiteSpace(secretKey))
+        {
+            throw new ArgumentException("Secret key must not be null, empty, or whitespace.", nameof(secretKey));
+        }
+            
         services
             .AddAuthentication(options =>
         {

--- a/LoyaltyCardsWebApi.API/Extensions/AuthenticationExtensions.cs
+++ b/LoyaltyCardsWebApi.API/Extensions/AuthenticationExtensions.cs
@@ -1,0 +1,94 @@
+using System.Text;
+using System.Text.Json;
+using LoyaltyCardsWebApi.API.Common;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+namespace LoyaltyCardsWebApi.API.Extensions;
+
+public static class AuthenticationExtensions
+{
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, string jwtIssuer, string jwtAudience, string secretKey)
+    {
+        services
+            .AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+        }).AddJwtBearer(options => 
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = jwtIssuer,
+                ValidAudience = jwtAudience,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey))
+            };
+
+            options.Events = new JwtBearerEvents
+            {
+                OnChallenge = async context =>
+                {
+                    context.HandleResponse();
+                    
+                    if (context.Response.HasStarted)
+                    {
+                        return;
+                    }
+                                    
+                    var statusCode = StatusCodes.Status401Unauthorized;
+                    var details = !string.IsNullOrEmpty(context.Error)
+                        ? context.Error : !string.IsNullOrEmpty(context.ErrorDescription)
+                            ? context.ErrorDescription : "Authentication failed.";
+                    var title = "Unauthorized.";
+
+                    var problemDetails = ProblemDetailsHelper.CreateProblemDetails(
+                            context.HttpContext,
+                            title,
+                            statusCode,
+                            details
+                        );
+                    context.Response.Clear();
+                    context.Response.StatusCode = statusCode;
+                    context.Response.ContentType = "application/problem+json; charset=utf-8";
+                    var json = JsonSerializer.Serialize(problemDetails);
+                    await context.Response.WriteAsync(json, Encoding.UTF8, context.HttpContext.RequestAborted);
+                },
+                OnForbidden = async context =>
+                {
+                    if (context.Response.HasStarted)
+                    {
+                        return;
+                    }
+
+                    var statusCode = StatusCodes.Status403Forbidden;
+                    var user = context.HttpContext.User;
+                    var path = context.HttpContext.Request.Path;
+                    var method = context.HttpContext.Request.Method;
+                    var details = user.Identity?.IsAuthenticated == true
+                        ? $"Access to {method} {path} is forbidden."
+                        : $"Access forbidden.";
+                    var title = "Access forbidden.";
+
+                    var problemDetails = ProblemDetailsHelper.CreateProblemDetails(
+                            context.HttpContext,
+                            title,
+                            statusCode,
+                            details
+                        );
+                    context.Response.Clear();
+                    context.Response.StatusCode = statusCode;
+                    context.Response.ContentType = "application/problem+json; charset=utf-8";
+                    var json = JsonSerializer.Serialize(problemDetails);
+                    await context.Response.WriteAsync(json, Encoding.UTF8, context.HttpContext.RequestAborted);
+                }
+            };
+        });
+
+        return services;
+    }
+}


### PR DESCRIPTION
Thank you for your contribution to the LoyaltyCardsWebApi repo.
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added unit tests

## Summary
This PR introduces an extension method for configuring JWT authentication and restructures the existing Program.cs setup to improve clarity, modularity, and configuration safety.
The unit test JwtBearerEventsCancellationTest has been updated to use DI-configured JwtBearerOptions instead of manually constructed handlers, ensuring test coverage aligns with real application behavior.
These changes make JWT configuration more maintainable, more reusable, and less error-prone, while keeping test behavior consistent with runtime execution.

### Key Changes:
#### AuthenticationExtensions
A new extension method ```AddJwtAuthentication(...)``` has been introduced:
 - Extracts all JWT configuration from Program.cs into a reusable module
 - Sets up:
   - JwtBearerDefaults.AuthenticationScheme,
   - TokenValidationParameters (issuer, audience, signing key),
   - Custom OnChallenge and OnForbidden handlers with ProblemDetails responses
 - Ensures consistent configuration across the entire application
This improves modularity and prevents duplication of complex authentication logic.

#### Program.cs cleanup
Authentication configuration was removed from Program.cs and replaced with:
```
builder.Services.AddJwtAuthentication(jwtIssuer, jwtAudience, secretKey);
```

Additionally, new validation checks were added:
 - ```JWT_Secret```,
 - ```JWT_Issuer```,
 - ```JWT_Audience```

If any value is missing, empty, or whitespace-only, a clear InvalidOperationException is thrown on startup.
This ensures that misconfigured environments fail fast instead of failing at runtime.

#### Updated JwtBearerEventsCancellationTest
```JwtBearerEventsCancellationTest``` was updated to reflect the new authentication architecture:
 - Removed manual new ```JwtBearerOptions { Events = ... }``` setup
 - Test now uses:
   - ```ServiceCollection```
   - ```AddJwtAuthentication(...)```
   - ```BuildServiceProvider()```
   - ```IOptionsMonitor<JwtBearerOptions>```

This change ensures the test verifies the real, DI-configured event handlers, instead of a manually duplicated version.
Additional improvements:
 - Injected ```RequestServices``` into ```HttpContext```, 
 - Significantly simplified test setup,
 - Eliminated duplicate logic between test and production code

The test continues to validate that cancellation tokens propagate correctly and that ```OperationCanceledException``` is thrown when ```RequestAborted``` is triggered.

### Behavior After Changes
 - Application now fails early during startup if JWT configuration is incomplete,
 - Authentication logic is fully encapsulated and reusable, 
 - Unit tests now verify the same event handlers used in production, 
 - Program.cs is cleaner, easier to read, and easier to maintain

### How to test
 - Run all unit tests - all JWT-related cancellation tests should pass,
 - Start the application with valid JWT configuration - it should run normally,
 - Start the application with missing or empty JWT settings - it should fail at startup with a clear error,
 - Manually test authentication:
   - Request any ```[Authorize]``` endpoint without a token gives ```401 Unauthorized```  Status Code with ```ProblemDetails```
   - Request with insufficient permissions gives ```403 Forbidden``` Status Code with ```ProblemDetails```